### PR TITLE
Forenlink update

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ SAMP UDF für AutoHotKey
 Version R 11.1
 ----------
 
-Hier geht's lang zum [Wiki](http://wiki.samp-udf.net/index.php?title=Hauptseite) und [Forum](http://forum.samp-udf.net)
+Hier geht's lang zum [Wiki](http://wiki.samp-udf.net/index.php?title=Hauptseite) und [Forum](http://samp-udf.net)
 ---
 
 Deutsch


### PR DESCRIPTION
Update des Forenlinks. Da die Subdomain "forum." nicht auf's Forum verweist.